### PR TITLE
clean up unnecessary code after 2.12 removal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,4 +58,10 @@ console / initialCommands := {
 
 /// MiMa
 
+import com.typesafe.tools.mima.core._, ProblemFilters._
 mimaPreviousArtifacts := Set(organization.value %% name.value % "1.3.0")
+// this can be removed once the reference version is bumped
+mimaBinaryIssueFilters ++= Seq(
+  exclude[MissingClassProblem]("com.lightbend.emoji.ScalaVersionSpecific"),
+  exclude[MissingClassProblem]("com.lightbend.emoji.ScalaVersionSpecific$"),
+)

--- a/src/main/scala-2.12/com/lightbend/emoji/ScalaVersionSpecific.scala
+++ b/src/main/scala-2.12/com/lightbend/emoji/ScalaVersionSpecific.scala
@@ -1,9 +1,0 @@
-/*
- * Copyright (C) Lightbend Inc. <http://www.lightbend.com>
- */
-package com.lightbend.emoji
-
-object ScalaVersionSpecific {
-  def checkLengths(sc: StringContext, args: Seq[Any]): Unit =
-    sc.checkLengths(args)
-}

--- a/src/main/scala-2.13/com/lightbend/emoji/ScalaVersionSpecific.scala
+++ b/src/main/scala-2.13/com/lightbend/emoji/ScalaVersionSpecific.scala
@@ -1,9 +1,0 @@
-/*
- * Copyright (C) Lightbend Inc. <http://www.lightbend.com>
- */
-package com.lightbend.emoji
-
-object ScalaVersionSpecific {
-  def checkLengths(sc: StringContext, args: Seq[Any]): Unit =
-    StringContext.checkLengths(args, sc.parts)
-}

--- a/src/main/scala-2/com/lightbend/emoji/ShortCodes.scala
+++ b/src/main/scala-2/com/lightbend/emoji/ShortCodes.scala
@@ -3,8 +3,6 @@
  */
 package com.lightbend.emoji
 
-import ScalaVersionSpecific.checkLengths
-
 /**
  * An emoji to shortcode mapping. This is a class that should be declared and used as an implicit
  * value, so that shortcode mappings don't have to be global across an application.
@@ -148,7 +146,7 @@ object ShortCodes {
             try m.group(1).emoji.toString
             catch { case _: EmojiNotFound => m.matched }
         )
-        checkLengths(sc, args)
+        StringContext.checkLengths(args, sc.parts)
         val sb = new java.lang.StringBuilder
         def process(part: String): String = emojify(StringContext.processEscapes(part))
         def partly(part: String): Unit = {

--- a/src/main/scala-3/com/lightbend/emoji/ScalaVersionSpecific.scala
+++ b/src/main/scala-3/com/lightbend/emoji/ScalaVersionSpecific.scala
@@ -1,8 +1,0 @@
-/*
- * Copyright (C) Lightbend Inc. <http://www.lightbend.com>
- */
-package com.lightbend.emoji
-
-object ScalaVersionSpecific:
-  def checkLengths(sc: StringContext, args: Seq[Any]): Unit =
-    StringContext.checkLengths(args, sc.parts)

--- a/src/main/scala-3/com/lightbend/emoji/ShortCodes.scala
+++ b/src/main/scala-3/com/lightbend/emoji/ShortCodes.scala
@@ -5,8 +5,6 @@ package com.lightbend.emoji
 
 import scala.util.chaining.given
 
-import ScalaVersionSpecific.checkLengths
-
 /**
  * An emoji to shortcode mapping. This is a class that should be declared and used as an implicit
  * value, so that shortcode mappings don't have to be global across an application.
@@ -133,7 +131,7 @@ object ShortCodes:
           try m.group(1).emoji.toString
           catch case _: EmojiNotFound => m.matched
       )
-      checkLengths(sc, args)
+      StringContext.checkLengths(args, sc.parts)
       val sb = new java.lang.StringBuilder
       def process(part: String): String = emojify(StringContext.processEscapes(part))
       def partly(part: String): Unit =


### PR DESCRIPTION
some stuff I missed in #291 

it would have been better if `ScalaVersionSpecific` hadn't been public. in order to remove it like this, technically we'll need to bump the major version, but that's fine for this silly library